### PR TITLE
Removed senior from principal consultant title

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -6,7 +6,7 @@ dieter_hubau:
   linkedin: dhubau
   permalink: /author/dieter-hubau/
   avatar: dieter-hubau.png
-  title: Senior Principal Consultant
+  title: Principal Consultant
   title2: Competence Leader Cloud and PaaS
   email: dieter.hubau@ordina.be
   phone: 0032478458150
@@ -19,7 +19,7 @@ tom_verelst:
   twitter: tomverelst
   linkedin: tomverelst
   github: tomverelst
-  title: Senior Principal Consultant
+  title: Principal Consultant
   title2: Coach
   email: tom.verelst@ordina.be
   bio: Tom is a senior developer and coach at Ordina Belgium. Some friends like to refer to him as a Java code monkey, which is not completely true! Tom is familiar with many different domains.  He loves to learn about everything. Currently he is very fond of Docker, Go and all things DevOps.<br /><br />In his spare time he likes spending time with friends, going out for a run with his marathon club or just swinging around some drum sticks.
@@ -28,7 +28,7 @@ andreas_evers:
   last_name: Evers
   permalink: /author/andreas-evers/
   avatar: andreas-evers.jpg
-  title: Senior Principal Consultant
+  title: Principal Consultant
   email: andreas.evers@ordina.be
   twitter: andreasevers
   github: andreasevers
@@ -43,7 +43,7 @@ ken_coenen:
   github: kencoenen
   permalink: /author/ken-coenen/
   avatar: ken-coenen.png
-  title: Senior Principal Consultant
+  title: Principal Consultant
   title2: Practice Leader Backend
   email: ken.coenen@ordina.be
   bio: Ken is a Principal Java Consultant at Ordina, passionate about all Java- and JavaScript related technologies. Aside from his day-to-day occupation as a consultant, he helps fellow developers as a Competence Leader for Architecture and Best Practices by giving workshops, talks and courses about the newest technologies.
@@ -67,7 +67,7 @@ tim_ysewyn:
   linkedin: tysewyn
   github: TYsewyn
   permalink: /author/tim-ysewyn/
-  title: Senior Principal Consultant
+  title: Principal Consultant
   title2: Competence Leader Microservices
   email: Tim.Ysewyn@ordina.be
   bio: Tim is a Senior Principal Consultant at Ordina, where he helps fellow developers discovering top-notch technologies and methodologies as a Competence Leader for Microservices. He also enjoys the different challenges while developing iOS applications with Objective-C and Swift.<br />When not working for Ordina, you can find him working on various parts of the [Spring](http://www.spring.io) framework.


### PR DESCRIPTION
The `Principal` title already implies seniority