### PR TITLE
Set permalink for devoxx pl post

### DIFF
--- a/_posts/2017-07-03-Devoxx-pl.md
+++ b/_posts/2017-07-03-Devoxx-pl.md
@@ -6,6 +6,7 @@ image: /img/2017-devoxx-pl/devoxx-poland.jpg
 tags: [Testing, Software Patterns, Git]
 category: Conference
 comments: true
+permalink: conference/2017/06/21/Devoxx-pl.html
 ---
 # Devoxx Poland 2017
 


### PR DESCRIPTION
Set permalink allowing to update the filename and thus the date without breaking original links.
This will set the post first when a new part is added but keep the original url.
More info: https://jekyllrb.com/docs/permalinks/