### PR TITLE
Fixes page going back to previous page instead of page 1 (#213)

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ transparent_header: true
                 {% for page in (1..paginator.total_pages) %}
                 {% if page == 1 %}
                 {% capture url %}
-                {{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}
+                {{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: 'page:num', '' }}
                 {% endcapture %}
                 {% else %}
                 {% capture url %}


### PR DESCRIPTION
Fixes the issue where clicking on page 1 takes you to the previous page. Didn't notice any other strange behaviour as mentioned by @MrJean ?