### PR TITLE
Set paginate to 12 (supports 3 items in a row)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ sass:
     style: compressed
 
 # Pagination
-paginate: 10
+paginate: 12
 
 collections:
     # Needed for our job board


### PR DESCRIPTION
Current pagination is not working out with 10 articles. 12 will work with 3/2/1 item(s) in a row.

![pagination-10](https://user-images.githubusercontent.com/13830735/35228523-3c82f27e-ff91-11e7-9ac1-d46c30d41040.jpg)