### PR TITLE
fix: Set color of bold text and table headers in dark mode to a lighter color

### DIFF
--- a/_sass/base/_page.scss
+++ b/_sass/base/_page.scss
@@ -406,5 +406,15 @@ body.custom-image {
     .wrapper.spotlight.post-body h1, .wrapper.spotlight.post-body h2 {
       color: #e98300;
     }
+
+    strong, b {
+      color: #ddd;
+    }
+
+    table {
+      th {
+        color: #ec9649;
+      }
+    }
   }
 }


### PR DESCRIPTION
When using dark mode, bold text and table headers are not readable (they are dark fg on dark bg).
These are higher contrast colors for dark mode users.