### PR TITLE
Separate pullrequest workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,3 +18,5 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         build_only: true
+        pre_build_commands: |
+          apk --update add imagemagick

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,20 @@
+name: Build Pull Request
+
+on:
+  pull_request:
+
+jobs:
+  build_pull_request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - uses: helaili/jekyll-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        build_only: true


### PR DESCRIPTION
This configuration will

- trigger on every pull request
- will do a checkout of said pull request
- will cache the Gems
- will start the jekyll build without actually publishing