### PR TITLE
chore: fix workflow concurrency

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,26 +5,29 @@ on:
     branches:
       - source
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   jekyll:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Gen Cache
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+      - name: Gen Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
-    # Specify the Jekyll source location as a parameter
-    - uses: helaili/jekyll-action@v2
-      with:
-        keep_history: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        target_branch: master
-        pre_build_commands: |
-          apk --update add imagemagick musl
+      # Specify the Jekyll source location as a parameter
+      - uses: helaili/jekyll-action@v2
+        with:
+          keep_history: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target_branch: master
+          pre_build_commands: |
+            apk --update add imagemagick musl

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,20 +3,24 @@ name: Build Pull Request
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_pull_request:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - uses: helaili/jekyll-action@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        build_only: true
-        pre_build_commands: |
-          apk --update add imagemagick musl
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: helaili/jekyll-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          build_only: true
+          pre_build_commands: |
+            apk --update add imagemagick musl


### PR DESCRIPTION
Fixes concurrency in workflows, prevents 2 deployments running at te same time and have a deployment race, the older commit might win, which means an outdated blog, which can happen if 2 pull request are merged closely behind each-other.

Fixed .yml file formatting

Cancel build if a newer commit has been submitted to a pull request.
