### PR TITLE
chore(ci): validate renovate config when changed

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,40 @@
+name: 'Validate Renovate config'
+
+on:
+  push:
+    branches: [ "source" ]
+    paths:
+      - 'renovate.json'
+  pull_request:
+    branches: [ "source" ]
+    paths:
+      - 'renovate.json'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-renovate-config:
+    name: 'Validate Renovate config'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          node-version: '18'
+
+      - name: Validate Renovate config
+        run: npx --package renovate -c renovate-config-validator


### PR DESCRIPTION
Add a CI workflow to check if our renovate config is valid, but only if the file has been modified.