### PR TITLE
fix: freeze lock-file

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_FROZEN: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ _site
 .idea
 *.DS_Store
 .jekyll-metadata
-.bundle/
 _posts/.vscode
 .jekyll-cache
 .vscode


### PR DESCRIPTION
Prevent users from downgrading lock-file when they are using older ruby versions

Renovate now updates lock-files for us, so we can safely use frozen lock-files.