### PR TITLE
chore(docker): rebuild the entire site in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       dockerfile: Dockerfile.build
       context: .
-    command: jekyll serve --incremental
+    command: jekyll serve
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
Resolves an issue where users running from the docker image end up with outdated index pages and can't find their blog post in categories or/and the index page.

This causes allot of confusions with users that have not written blogposts before, removing --incremental will fix this issue.