### PR TITLE
chore: fix docker image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,10 @@
-FROM jekyll/jekyll:4.2.2@sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625
-# Image to use M1 Macs
-# FROM younglook/jekyll-arm64:latest
+FROM ruby:3.2.2@sha256:9d51b178e1231df7d4222e7c288bf5b8b3191a9df41ce37457c48a9efb4f60c5
 
+RUN apt-get update
 # install imagemagick
-RUN apk update && apk add imagemagick
+RUN apt-get install imagemagick
+
+WORKDIR /srv/jekyll
+VOLUME [/srv/jekyll]
+EXPOSE 35729
+EXPOSE 4000

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://ordina-jworks.github.io" # the base hostname & protocol for your site
 github_username:  ordina-jworks
 facebook: lifeatordinabe
-
 # Plugins
 plugins: [jekyll-paginate, jekyll-feed, jekyll-redirect-from]
 whitelist: [jekyll-redirect-from]
@@ -40,3 +39,6 @@ defaults:
       active: true
 
 keep_files: [.git, img]
+
+exclude:
+  - .idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,12 @@ services:
     build:
       dockerfile: Dockerfile.build
       context: .
-    command: jekyll serve
+    command:
+      - /bin/sh
+      - -c
+      - |
+        bundle install
+        jekyll serve --host=0.0.0.0
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
fix the docker image that is created to run the site, the jekyll image is not updated so regulary and only supports x64, the new Dockerfile.build will make sure the image is either (intel) x64 or arm64 depending on the system and uses the latest ruby version.